### PR TITLE
Correct spelling of function pointer

### DIFF
--- a/ESP8266_MAX7219_Message_Board_AP.ino.ino
+++ b/ESP8266_MAX7219_Message_Board_AP.ino.ino
@@ -68,7 +68,7 @@ void setup() {
   Serial.print(F("Use this URL to connect: http://")); Serial.println(WiFi.softAPIP().toString() + "/"); // Print the IP address
 
   //----------------------------------------------------------------------
-  server.on("/",GetMEssage);
+  server.on("/",GetMessage);
   server.begin(); Serial.println(F("Webserver started..."));
   matrix.setIntensity(2);    // Use a value between 0 and 15 for brightness
   matrix.setRotation(0, 1);  // The first display is position upside down


### PR DESCRIPTION
Previously, compilation would fail:
```
ESP8266-Remote-Message-Board-master\ESP8266_MAX7219_Message_Board_AP.ino\ESP8266_MAX7219_Message_Board_AP.ino.ino: In function 'void setup()':

ESP8266_MAX7219_Message_Board_AP.ino:71:17: error: 'GetMEssage' was not declared in this scope

   server.on("/",GetMEssage);

                 ^
```

Fixes https://github.com/G6EJD/ESP8266-Remote-Message-Board/issues/4

CC: @LenK13